### PR TITLE
Feat: /positions 관련 api 추가

### DIFF
--- a/backend/src/main/java/com/recareer/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/recareer/backend/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/auth/**", "/profile/**", "/user/**", "/personality-tags/**", "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**").permitAll()
+                        .requestMatchers("/", "/auth/**", "/profile/**", "/user/**", "/personality-tags/**", "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**", "/positions/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
@@ -47,7 +47,7 @@ public class SecurityConfig {
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureHandler(oAuth2AuthenticationFailureHandler)
                 )
-                .headers(headers -> headers.frameOptions().disable());
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()));
 
         return http.build();
     }

--- a/backend/src/main/java/com/recareer/backend/mentor/repository/MentorRepository.java
+++ b/backend/src/main/java/com/recareer/backend/mentor/repository/MentorRepository.java
@@ -3,9 +3,15 @@ package com.recareer.backend.mentor.repository;
 import com.recareer.backend.mentor.entity.Mentor;
 import com.recareer.backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
     Optional<Mentor> findByUser(User user);
+    
+    @Query("SELECT m.position, COUNT(m) FROM Mentor m JOIN m.user u WHERE m.isVerified = true AND u.role = 'MENTOR' AND (u.region LIKE %:region% OR :region LIKE CONCAT('%', u.region, '%')) GROUP BY m.position ORDER BY COUNT(m) DESC limit 4")
+    List<Object[]> countPositionsByRegion(@Param("region") String region);
 }

--- a/backend/src/main/java/com/recareer/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/recareer/backend/news/controller/NewsController.java
@@ -1,0 +1,28 @@
+package com.recareer.backend.news.controller;
+
+import com.recareer.backend.news.dto.NewsDto;
+import com.recareer.backend.news.service.NewsService;
+import com.recareer.backend.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/news")
+@RequiredArgsConstructor
+@Tag(name = "News", description = "뉴스 API")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @GetMapping
+    @Operation(summary = "뉴스 리스트 조회", description = "등록된 모든 뉴스를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<NewsDto>>> getAllNews() {
+        List<NewsDto> newsList = newsService.getAllNews();
+        return ResponseEntity.ok(ApiResponse.success(newsList));
+    }
+}

--- a/backend/src/main/java/com/recareer/backend/news/dto/NewsDto.java
+++ b/backend/src/main/java/com/recareer/backend/news/dto/NewsDto.java
@@ -1,0 +1,16 @@
+package com.recareer.backend.news.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsDto {
+    private Long id;
+    private String title;
+    private String description;
+    private String url;
+    private String category;
+}

--- a/backend/src/main/java/com/recareer/backend/news/entity/News.java
+++ b/backend/src/main/java/com/recareer/backend/news/entity/News.java
@@ -1,0 +1,31 @@
+package com.recareer.backend.news.entity;
+
+import com.recareer.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "news")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class News extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 20)
+    private String title;
+
+    @Column(name = "description", length = 100)
+    private String description;
+
+    @Column(name = "url", nullable = false, length = 256)
+    private String url;
+
+    @Column(name = "category", length = 50)
+    private String category;
+}

--- a/backend/src/main/java/com/recareer/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/com/recareer/backend/news/repository/NewsRepository.java
@@ -1,0 +1,9 @@
+package com.recareer.backend.news.repository;
+
+import com.recareer.backend.news.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsRepository extends JpaRepository<News, Long> {
+}

--- a/backend/src/main/java/com/recareer/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/recareer/backend/news/service/NewsService.java
@@ -1,0 +1,35 @@
+package com.recareer.backend.news.service;
+
+import com.recareer.backend.news.dto.NewsDto;
+import com.recareer.backend.news.entity.News;
+import com.recareer.backend.news.repository.NewsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+
+    private final NewsRepository newsRepository;
+
+    @Transactional(readOnly = true)
+    public List<NewsDto> getAllNews() {
+        return newsRepository.findAll().stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    private NewsDto convertToDto(News news) {
+        return NewsDto.builder()
+                .id(news.getId())
+                .title(news.getTitle())
+                .description(news.getDescription())
+                .url(news.getUrl())
+                .category(news.getCategory())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/recareer/backend/position/controller/PositionController.java
+++ b/backend/src/main/java/com/recareer/backend/position/controller/PositionController.java
@@ -1,0 +1,46 @@
+package com.recareer.backend.position.controller;
+
+import com.recareer.backend.position.dto.PositionDto;
+import com.recareer.backend.position.dto.PositionSimpleDto;
+import com.recareer.backend.position.dto.RegionPositionRequestDto;
+import com.recareer.backend.position.dto.RegionPositionResponseDto;
+import com.recareer.backend.position.service.PositionService;
+import com.recareer.backend.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/positions")
+@RequiredArgsConstructor
+@Tag(name = "Position", description = "직무 정보 관리 API")
+public class PositionController {
+
+    private final PositionService positionService;
+
+    @GetMapping("/trend-20")
+    @Operation(summary = "트렌드 TOP 20 직무 조회", description = "최근 트렌드 20 직무 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<PositionSimpleDto>>> getTrand20Positions() {
+        List<PositionSimpleDto> trand20Positions = positionService.getTrand20Positions();
+        return ResponseEntity.ok(ApiResponse.success(trand20Positions));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "직무 상세 조회", description = "특정 직무의 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<PositionDto>> getPositionById(@PathVariable Long id) {
+        PositionDto position = positionService.getPositionById(id);
+        return ResponseEntity.ok(ApiResponse.success(position));
+    }
+
+    @GetMapping("/by-region")
+    @Operation(summary = "지역별 직무 조회", description = "특정 지역의 멘토가 많은 직무 4개 또는 랜덤 직무 4개를 조회합니다.")
+    public ResponseEntity<ApiResponse<RegionPositionResponseDto>> getPositionsByRegion(@RequestBody RegionPositionRequestDto request) {
+        RegionPositionResponseDto response = positionService.getPositionsByRegion(request.getRegion());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/backend/src/main/java/com/recareer/backend/position/dto/PositionDto.java
+++ b/backend/src/main/java/com/recareer/backend/position/dto/PositionDto.java
@@ -1,0 +1,20 @@
+package com.recareer.backend.position.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PositionDto {
+    private Long id;
+    private String name;
+    private Integer trendRank;
+    private String imageUrl;
+    private String category;
+    private String description;
+    private String industryTrends;
+    private List<PositionResponsibilitiesDto> positionResponsibilities;
+}

--- a/backend/src/main/java/com/recareer/backend/position/dto/PositionResponsibilitiesDto.java
+++ b/backend/src/main/java/com/recareer/backend/position/dto/PositionResponsibilitiesDto.java
@@ -1,0 +1,14 @@
+package com.recareer.backend.position.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PositionResponsibilitiesDto {
+    private Long id;
+    private String name;
+    private String imageUrl;
+}

--- a/backend/src/main/java/com/recareer/backend/position/dto/PositionSimpleDto.java
+++ b/backend/src/main/java/com/recareer/backend/position/dto/PositionSimpleDto.java
@@ -1,0 +1,15 @@
+package com.recareer.backend.position.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PositionSimpleDto {
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private String category;
+}

--- a/backend/src/main/java/com/recareer/backend/position/dto/PositionWithResponsibilitiesDto.java
+++ b/backend/src/main/java/com/recareer/backend/position/dto/PositionWithResponsibilitiesDto.java
@@ -1,0 +1,19 @@
+package com.recareer.backend.position.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PositionWithResponsibilitiesDto {
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private String category;
+    private String description;
+    private String industryTrends;
+    private List<PositionResponsibilitiesDto> responsibilities;
+}

--- a/backend/src/main/java/com/recareer/backend/position/dto/RegionPositionRequestDto.java
+++ b/backend/src/main/java/com/recareer/backend/position/dto/RegionPositionRequestDto.java
@@ -1,0 +1,12 @@
+package com.recareer.backend.position.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegionPositionRequestDto {
+    private String region;
+}

--- a/backend/src/main/java/com/recareer/backend/position/dto/RegionPositionResponseDto.java
+++ b/backend/src/main/java/com/recareer/backend/position/dto/RegionPositionResponseDto.java
@@ -1,0 +1,14 @@
+package com.recareer.backend.position.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegionPositionResponseDto {
+    private String region;
+    private List<PositionSimpleDto> positions;
+}

--- a/backend/src/main/java/com/recareer/backend/position/entity/Position.java
+++ b/backend/src/main/java/com/recareer/backend/position/entity/Position.java
@@ -1,0 +1,37 @@
+package com.recareer.backend.position.entity;
+
+import com.recareer.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "positions")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Position extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "trend_rank", nullable = true)
+    private Integer trendRank;
+
+    @Column(name = "image_url", length = 256)
+    private String imageUrl;
+
+    @Column(name = "category", length = 50)
+    private String category;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "industry_trends", columnDefinition = "TEXT")
+    private String industryTrends;
+}

--- a/backend/src/main/java/com/recareer/backend/position/entity/PositionResponsibilities.java
+++ b/backend/src/main/java/com/recareer/backend/position/entity/PositionResponsibilities.java
@@ -1,0 +1,25 @@
+package com.recareer.backend.position.entity;
+
+import com.recareer.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "position_responsibilities")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PositionResponsibilities extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 20)
+    private String name;
+
+    @Column(name = "image_url", length = 256)
+    private String imageUrl;
+}

--- a/backend/src/main/java/com/recareer/backend/position/entity/PositionResponsibilityMap.java
+++ b/backend/src/main/java/com/recareer/backend/position/entity/PositionResponsibilityMap.java
@@ -1,0 +1,27 @@
+package com.recareer.backend.position.entity;
+
+import com.recareer.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "position_responsibility_map")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PositionResponsibilityMap extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "position_id", nullable = false)
+    private Position position;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "responsibility_id", nullable = false)
+    private PositionResponsibilities positionResponsibilities;
+}

--- a/backend/src/main/java/com/recareer/backend/position/repository/PositionRepository.java
+++ b/backend/src/main/java/com/recareer/backend/position/repository/PositionRepository.java
@@ -1,0 +1,19 @@
+package com.recareer.backend.position.repository;
+
+import com.recareer.backend.position.entity.Position;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PositionRepository extends JpaRepository<Position, Long> {
+    List<Position> findByTrendRankIsNotNullAndTrendRankLessThanEqualOrderByTrendRankAsc(Integer trendRank);
+    
+    @Query(value = "SELECT * FROM positions WHERE trend_rank IS NULL ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+    List<Position> findRandomPositionsWithNullTrendRank(@Param("limit") int limit);
+    
+    List<Position> findByNameIn(List<String> names);
+}

--- a/backend/src/main/java/com/recareer/backend/position/repository/PositionResponsibilitiesRepository.java
+++ b/backend/src/main/java/com/recareer/backend/position/repository/PositionResponsibilitiesRepository.java
@@ -1,0 +1,10 @@
+package com.recareer.backend.position.repository;
+
+import com.recareer.backend.position.entity.PositionResponsibilities;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PositionResponsibilitiesRepository extends JpaRepository<PositionResponsibilities, Long> {
+
+}

--- a/backend/src/main/java/com/recareer/backend/position/repository/PositionResponsibilityMapRepository.java
+++ b/backend/src/main/java/com/recareer/backend/position/repository/PositionResponsibilityMapRepository.java
@@ -1,0 +1,12 @@
+package com.recareer.backend.position.repository;
+
+import com.recareer.backend.position.entity.PositionResponsibilityMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PositionResponsibilityMapRepository extends JpaRepository<PositionResponsibilityMap, Long> {
+    List<PositionResponsibilityMap> findByPositionId(Long positionId);
+}

--- a/backend/src/main/java/com/recareer/backend/position/service/PositionService.java
+++ b/backend/src/main/java/com/recareer/backend/position/service/PositionService.java
@@ -1,0 +1,121 @@
+package com.recareer.backend.position.service;
+
+import com.recareer.backend.mentor.repository.MentorRepository;
+import com.recareer.backend.position.dto.PositionDto;
+import com.recareer.backend.position.dto.PositionResponsibilitiesDto;
+import com.recareer.backend.position.dto.PositionSimpleDto;
+import com.recareer.backend.position.dto.RegionPositionResponseDto;
+import com.recareer.backend.position.entity.Position;
+import com.recareer.backend.position.entity.PositionResponsibilities;
+import com.recareer.backend.position.entity.PositionResponsibilityMap;
+import com.recareer.backend.position.repository.PositionRepository;
+import com.recareer.backend.position.repository.PositionResponsibilityMapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PositionService {
+
+    private final PositionRepository positionRepository;
+    private final PositionResponsibilityMapRepository positionResponsibilityMapRepository;
+    private final MentorRepository mentorRepository;
+
+    @Transactional(readOnly = true)
+    public List<PositionSimpleDto> getTrand20Positions() {
+        return positionRepository.findByTrendRankIsNotNullAndTrendRankLessThanEqualOrderByTrendRankAsc(20).stream()
+                .map(this::convertToSimpleDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public PositionDto getPositionById(Long id) {
+        Position position = positionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Position not found with id: " + id));
+        
+        List<PositionResponsibilityMap> maps = positionResponsibilityMapRepository.findByPositionId(id);
+        List<PositionResponsibilitiesDto> responsibilities = maps.stream()
+                .map(map -> convertToDto(map.getPositionResponsibilities()))
+                .collect(Collectors.toList());
+        
+        return convertToDtoWithResponsibilities(position, responsibilities);
+    }
+
+    @Transactional(readOnly = true)
+    public RegionPositionResponseDto getPositionsByRegion(String region) {
+        List<PositionSimpleDto> positions;
+        String resultRegion;
+        
+        if ("all".equalsIgnoreCase(region)) {
+            // region이 "all"이면 trendRank가 null인 것들을 랜덤으로 4개 조회
+            List<Position> randomPositions = positionRepository.findRandomPositionsWithNullTrendRank(4);
+            positions = randomPositions.stream()
+                    .map(this::convertToSimpleDto)
+                    .collect(Collectors.toList());
+            resultRegion = "all";
+        } else {
+            // 특정 지역의 멘토들의 position count 조회 (상위 4개)
+            List<Object[]> positionCounts = mentorRepository.countPositionsByRegion(region);
+            
+            if (positionCounts.size() >= 4) {
+                // 4개 이상이면 상위 4개의 position name으로 Position 조회
+                List<String> topPositionNames = positionCounts.stream()
+                        .limit(4)
+                        .map(result -> (String) result[0])
+                        .collect(Collectors.toList());
+                
+                List<Position> topPositions = positionRepository.findByNameIn(topPositionNames);
+                positions = topPositions.stream()
+                        .map(this::convertToSimpleDto)
+                        .collect(Collectors.toList());
+                resultRegion = region;
+            } else {
+                // 4개 미만이면 trendRank가 null인 것들을 랜덤으로 4개 조회
+                List<Position> randomPositions = positionRepository.findRandomPositionsWithNullTrendRank(4);
+                positions = randomPositions.stream()
+                        .map(this::convertToSimpleDto)
+                        .collect(Collectors.toList());
+                resultRegion = "all";
+            }
+        }
+        
+        return RegionPositionResponseDto.builder()
+                .region(resultRegion)
+                .positions(positions)
+                .build();
+    }
+
+    private PositionDto convertToDtoWithResponsibilities(Position position, List<PositionResponsibilitiesDto> responsibilities) {
+        return PositionDto.builder()
+                .id(position.getId())
+                .name(position.getName())
+                .trendRank(position.getTrendRank())
+                .imageUrl(position.getImageUrl())
+                .category(position.getCategory())
+                .description(position.getDescription())
+                .industryTrends(position.getIndustryTrends())
+                .positionResponsibilities(responsibilities)
+                .build();
+    }
+
+    private PositionSimpleDto convertToSimpleDto(Position position) {
+        return PositionSimpleDto.builder()
+                .id(position.getId())
+                .name(position.getName())
+                .imageUrl(position.getImageUrl())
+                .category(position.getCategory())
+                .build();
+    }
+
+    private PositionResponsibilitiesDto convertToDto(PositionResponsibilities responsibility) {
+        return PositionResponsibilitiesDto.builder()
+                .id(responsibility.getId())
+                .name(responsibility.getName())
+                .imageUrl(responsibility.getImageUrl())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 PR 내용 요약

## 관련 이슈

- https://github.com/Re-Career/Re-Career/issues/11

### 관련 테이블

- positions, position_responsibilities, position_responsibility_map

### 구현 기능

[홈 화면에 필요한 API 추가] (우선 데이터 먼저 미리 넣어두고 관리 시스템은 따로 추가할 예정)
- GET /positions/trend-20 트렌드 20 직무 리스트
- GET /positions/{id} 직무 데이터 상세 조회
- GET /positions/by-region 지역별 주요직업 (없거나 부족하면 랜덤으로 4개 전달)
- GET /news 직무 관련 뉴스 조회 

### 기타 변경사항

- Security config 파일에서 frameOptions 부분이 deprecated 되어 빌드에러가 발생해 수정하였습니다.

---

## ✅ 주요 변경 사항

- 위 API 구현

---

## 🔁 테스트 방법

1. 이전과 동일

