### PR TITLE
✨ Fix: 로그인  수정

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -42,7 +42,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-validity-in-seconds: 10800
+  access-token-validity-in-seconds: 1800 #30분
   refresh-token-validity-in-seconds: 604800
 
 cors:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -51,7 +51,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-validity-in-seconds: 86400 # @TODO: 30분으로 변경 (카카오 oauth 무한 요청으로 인한 문제로 24H)
+  access-token-validity-in-seconds: 1800 # 30분
   refresh-token-validity-in-seconds: 604800
 
 app:

--- a/frontend/career-web/src/lib/middleware/oauth.ts
+++ b/frontend/career-web/src/lib/middleware/oauth.ts
@@ -44,7 +44,8 @@ export async function handleOAuth2Redirect(
     }
 
     // 정상 로그인된 유저
-    const redirectUrl = request.cookies.get('redirectUrl')?.value || '/my-page'
+    const rawRedirectUrl = request.cookies.get('redirectUrl')?.value || '/my-page'
+    const redirectUrl = decodeURIComponent(rawRedirectUrl)
     const response = NextResponse.redirect(new URL(redirectUrl, request.url))
 
     response.cookies.set('accessToken', accessToken, {

--- a/frontend/career-web/src/lib/utils/jwt-validator.ts
+++ b/frontend/career-web/src/lib/utils/jwt-validator.ts
@@ -15,7 +15,7 @@ export const isTokenValid = (token: string): boolean => {
 
     const payload = JSON.parse(atob(parts[1])) as JWTPayload
     const currentTime = Math.floor(Date.now() / 1000)
-    const isExpired = payload.exp > currentTime
+    const isExpired = payload.exp <= currentTime
 
     // 토큰이 만료되지 않았고, 필수 필드가 있는지 확인
     return !isExpired && !!payload.sub && !!payload.role


### PR DESCRIPTION
## 📌 PR 내용 요약

## 이슈 내용
- 카카오 로그인 정상적으로 완료 후 다시 로그인 페이지로 돌아오는 이슈
- 이후 재접속 하면 my-page 정상적으로 접근 가능

## ✅ 주요 변경 사항
- 프론트 redirect 쿠키 저장 시 인코딩되어 저장되어 디코딩해서 조회
- isExpired 조건 수정
- 테스트로 토큰 만료기간 늘려놨던 부분 다시 30분으로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - OAuth 로그인 리디렉트 URL을 안전하게 디코딩하여 잘못된 경로 이동/무한 리디렉션을 방지했습니다.
  - JWT 만료 판정 로직을 수정해 만료 시각과 동일한 경우 즉시 만료로 처리합니다.
- Chores
  - 개발·운영 환경의 액세스 토큰 유효기간을 30분으로 단축·통일해 보안을 강화하고 자동 로그아웃 주기의 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->